### PR TITLE
Add date-aware history events and deduplication

### DIFF
--- a/prompt.txt
+++ b/prompt.txt
@@ -3,7 +3,8 @@ Each existing row has the format:
 timestamp,random_uuid,title
 
 Use the previous titles and timestamps as inspiration for the next entry so the narrative slowly evolves over time.
-When writing, feel free to reference notable historical events that happened on this month and day in past years.
+When writing, reference a notable historical event that occurred on {current_date} in some past year.
+Avoid repeating events from these dates: {events_to_avoid}.
 The content should be fully fictional and may feature any characters or settings—not just AI.
 
 Each row should contain a single title wrapped in [START] and [END].


### PR DESCRIPTION
## Summary
- inject current date and previously used historical event dates into the prompt
- avoid repeating events by extracting dates from prior entries
- update prompt template to accept `current_date` and `events_to_avoid`

## Testing
- `python3 -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6871cd086af88325b43db606689948b9