### PR TITLE
Refine prompt to focus on historically significant events

### DIFF
--- a/prompt.txt
+++ b/prompt.txt
@@ -3,7 +3,7 @@ Each existing row has the format:
 timestamp,random_uuid,title
 
 Use the previous titles and timestamps as inspiration for the next entry so the narrative slowly evolves over time.
-When writing, reference a notable historical event that occurred on {current_date} in some past year.
+When writing, reference a historically significant event that occurred on {current_date} in some past year.
 Avoid repeating events from these dates: {events_to_avoid}.
 The content should be fully fictional and may feature any characters or settings—not just AI.
 


### PR DESCRIPTION
## Summary
- tweak `prompt.txt` to request historically significant events on the same date in prior years

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6871da93936883258f6dc514425cc1d8